### PR TITLE
Migrate to Bevy 16 from Bevy 15 

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo check:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(cargo check:*)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.claude
+.qodo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_observed_utility"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Christian Hughes"]
 description = "Ergonomic and Correct Utility AI for Bevy Engine"
@@ -15,7 +15,7 @@ readme = "README.md"
 default = []
 
 [dependencies]
-bevy = { version = "0.16.1", default-features = false }
+bevy = { version = "0.17", default-features = false }
 hashbrown = "0.15"
 rand = { version = "0.9.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ default = []
 
 [dependencies]
 bevy = { version = "0.17", default-features = false }
-hashbrown = "0.15"
+hashbrown = "0.16.1"
 rand = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
-criterion = "0.7.0"
+criterion = "0.8.1"
 rand = { version = "0.9", features = ["std_rng"] }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_observed_utility"
-version = "0.2.0"
-edition = "2021"
+version = "0.2.1"
+edition = "2024"
 authors = ["Christian Hughes"]
 description = "Ergonomic and Correct Utility AI for Bevy Engine"
 categories = ["game-development"]
@@ -15,13 +15,14 @@ readme = "README.md"
 default = []
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
-rand = { version = "0.9", optional = true }
+bevy = { version = "0.16.1", default-features = false }
+hashbrown = "0.15"
+rand = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
-criterion = "0.5.1"
-rand = { version = "0.9", features = ["std_rng"]}
+criterion = "0.7.0"
+rand = { version = "0.9", features = ["std_rng"] }
 
 [[bench]]
 name = "score"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_observed_utility"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Christian Hughes"]
 description = "Ergonomic and Correct Utility AI for Bevy Engine"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,10 @@ See the [documentation](https://docs.rs/bevy_observed_utility/latest/bevy_observ
 
 ```toml
 [dependencies]
-bevy_observed_utility = "0.3.0"
+bevy_observed_utility = "0.4.0"
 ```
 
-| Bevy Version | Crate Version |
-|--------------|---------------|
-| 0.14         | 0.1.0         |
-| 0.15         | 0.2.0         |
-| 0.16         | 0.3.0         |
+Requires Bevy 0.17.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ See the [documentation](https://docs.rs/bevy_observed_utility/latest/bevy_observ
 bevy_observed_utility = "0.4.0"
 ```
 
-Requires Bevy 0.17.
+| bevy | bevy_observed_utility |
+| ---- | --------------------- |
+| 0.17 | 0.4                   |
+| 0.16 | 0.3                   |
+| 0.15 | 0.2                   |
+| 0.14 | 0.1                   |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,21 @@ See the [documentation](https://docs.rs/bevy_observed_utility/latest/bevy_observ
 
 ```toml
 [dependencies]
-bevy_observed_utility = "0.2.0"
+bevy_observed_utility = "0.3.0"
 ```
 
 | Bevy Version | Crate Version |
 |--------------|---------------|
 | 0.14         | 0.1.0         |
 | 0.15         | 0.2.0         |
+| 0.16         | 0.3.0         |
 
 ## Features
 
 - Minimal boilerplate: Add utility AI to pre-existing entities with little ceremony.
 - Highly expressive: Build scoring hierarchies for whatever occasion, as complex or as simple as needed.
 - Order-correct scoring: Hierarchies score their children before their parents.
-- Familiar design: Reuses standard `Parent`/`Children` hierarchy components to build actor entities that select actions based on their child score entities.
+- Familiar design: Reuses standard `ChildOf`/`Children` hierarchy components to build actor entities that select actions based on their child score entities.
 - Pay-for-what-you-use performance: Scoring and Picking variants' observers are only registered when they're spawned for the first time.
 - Game flow agnostic: Works well with both real-time and turn-based game simulation.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ See the [documentation](https://docs.rs/bevy_observed_utility/latest/bevy_observ
 [dependencies]
 bevy_observed_utility = "0.4.0"
 ```
+## Bevy Compatibility
 
 | bevy | bevy_observed_utility |
 | ---- | --------------------- |

--- a/benches/score.rs
+++ b/benches/score.rs
@@ -3,7 +3,7 @@ use bevy_observed_utility::{
     event::RunScoring,
     scoring::{AllOrNothing, FixedScore, Score, ScoringPlugin},
 };
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 
 fn score(c: &mut Criterion) {
     c.bench_function("score/deep-3", |b| {

--- a/benches/score.rs
+++ b/benches/score.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{BuildChildren, Commands, World};
+use bevy::prelude::{ChildOf, Commands, World};
 use bevy_observed_utility::{
     event::RunScoring,
     scoring::{AllOrNothing, FixedScore, Score, ScoringPlugin},
@@ -18,10 +18,10 @@ fn score(c: &mut Criterion) {
     c.bench_function("score/deep-3/many-100", |b| {
         bench_scoring(b, 3, 100);
     });
-    c.bench_function("score/deep-3/many-100", |b| {
+    c.bench_function("score/deep-10/many-100", |b| {
         bench_scoring(b, 10, 100);
     });
-    c.bench_function("score/deep-3/many-100", |b| {
+    c.bench_function("score/deep-25/many-100", |b| {
         bench_scoring(b, 25, 100);
     });
     c.bench_function("score/deep-3/many-10000", |b| {
@@ -54,13 +54,13 @@ fn build_deep_tree(mut commands: Commands, depth: usize) {
     for _ in 0..depth - 2 {
         last = commands
             .spawn((AllOrNothing::new(0.5), Score::default()))
-            .set_parent(last)
+            .insert(ChildOf(last))
             .id();
     }
 
     commands
         .spawn((FixedScore::new(0.5), Score::default()))
-        .set_parent(last);
+        .insert(ChildOf(last));
 }
 
 criterion_group!(benches, score);

--- a/benches/score.rs
+++ b/benches/score.rs
@@ -43,7 +43,7 @@ fn bench_scoring(b: &mut Bencher, scoring_depth: usize, num_trees: usize) {
     }
     world.flush();
     b.iter(|| {
-        world.trigger(RunScoring);
+        world.trigger(RunScoring::all());
     });
 }
 

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::component::ComponentId, log::LogPlugin, prelude::*};
+use bevy::{ecs::component::ComponentId, prelude::*};
 use bevy_observed_utility::prelude::*;
 
 #[derive(Component)]
@@ -19,7 +19,7 @@ impl From<&Thirst> for Score {
 pub fn get_thirsty_over_time(time: Res<Time<Fixed>>, mut thirsts: Query<&mut Thirst>) {
     for mut thirst in thirsts.iter_mut() {
         thirst.value = (thirst.value + thirst.per_second * time.delta_secs()).min(100.);
-        info!("Thirst: {}", thirst.value);
+        println!("Thirst: {}", thirst.value);
     }
 }
 
@@ -70,7 +70,7 @@ pub fn quench_thirst(
 ) {
     for (actor, mut thirst, drink) in drinking.iter_mut() {
         thirst.value = (thirst.value - drink.per_second * time.delta_secs()).max(0.);
-        info!("DRINKING!");
+        println!("DRINKING!");
         if thirst.value <= drink.until {
             commands.trigger_targets(
                 OnActionEnded {
@@ -105,10 +105,6 @@ impl FromWorld for ActionIds {
 fn main() {
     App::new()
         .add_plugins(MinimalPlugins)
-        .add_plugins(LogPlugin {
-            filter: "thirst=debug".to_string(),
-            ..default()
-        })
         .add_plugins(ObservedUtilityPlugins::RealTime)
         .init_resource::<ActionIds>()
         .init_resource::<Drinking>()

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -72,13 +72,7 @@ pub fn quench_thirst(
         thirst.value = (thirst.value - drink.per_second * time.delta_secs()).max(0.);
         println!("DRINKING!");
         if thirst.value <= drink.until {
-            commands.trigger_targets(
-                OnActionEnded {
-                    action: actions.drink,
-                    reason: ActionEndReason::Completed,
-                },
-                TargetedAction(actor, actions.drink),
-            )
+            commands.trigger(OnActionEnded::completed(actor, actions.drink));
         }
     }
 }

--- a/src/acting.rs
+++ b/src/acting.rs
@@ -47,7 +47,7 @@ impl ActionPlugin {
         mut commands: Commands,
         mut actors: Query<(&Picker, Option<&CurrentAction>)>,
     ) {
-        let actor = trigger.entity();
+        let actor = trigger.target();
         let requested = trigger.event().action;
         if let Ok((picker, current_action)) = actors.get_mut(actor) {
             let current_action = current_action.map(|ca| ca.0);
@@ -78,7 +78,7 @@ impl ActionPlugin {
 
     /// [`Observer`] that listens for [`OnActionEnded`] events and triggers a new [`RequestAction`] event for the target actor entity.
     pub fn on_ended_request_again(trigger: Trigger<OnActionEnded>, mut commands: Commands) {
-        let actor = trigger.entity();
+        let actor = trigger.target();
 
         match trigger.event().reason {
             ActionEndReason::Completed => {
@@ -112,7 +112,7 @@ pub fn on_action_initiated_insert_default<Action: Component + Default>(
     trigger: Trigger<OnActionInitiated, Action>,
     mut commands: Commands,
 ) {
-    let actor = trigger.entity();
+    let actor = trigger.target();
     commands.entity(actor).insert(Action::default());
 }
 
@@ -126,13 +126,13 @@ pub fn on_action_initiated_insert_from_resource<Action: Component + Resource + C
     mut commands: Commands,
     resource: Res<Action>,
 ) {
-    let actor = trigger.entity();
+    let actor = trigger.target();
     commands.entity(actor).insert(resource.clone());
 }
 
 /// [`Observer`] that listens for [`OnActionEnded`] events targeting
 /// the specified `Action` [`Component`] and removes the component from the actor entity.
 pub fn on_action_ended_remove<Action: Component>(trigger: Trigger<OnActionEnded, Action>, mut commands: Commands) {
-    let actor = trigger.entity();
+    let actor = trigger.target();
     commands.entity(actor).remove::<Action>();
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -45,14 +45,34 @@ use bevy::{ecs::component::ComponentId, prelude::*};
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 #[reflect(PartialEq, Debug, Default)]
-pub struct RunScoring;
+pub struct RunScoring {
+    /// The target entity to score, or [`None`] to score all entities.
+    pub entity: Option<Entity>,
+}
+
+impl RunScoring {
+    /// Creates a new [`RunScoring`] event for all entities.
+    #[must_use]
+    pub fn all() -> Self {
+        Self { entity: None }
+    }
+
+    /// Creates a new [`RunScoring`] event for a specific entity.
+    #[must_use]
+    pub fn entity(entity: Entity) -> Self {
+        Self { entity: Some(entity) }
+    }
+}
 
 /// This [`Event`] is listened to by scoring systems to calculate the score(s) for a given entity.
 /// DO NOT TRIGGER MANUALLY, trigger [`RunScoring`] instead.
 #[derive(Event, Reflect)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(PartialEq, Debug, Default)]
-pub struct OnScore;
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[reflect(PartialEq, Debug)]
+pub struct OnScore {
+    /// The entity being scored.
+    pub entity: Entity,
+}
 
 ////////////////////////////////////////////////////////////
 // Picking events
@@ -63,13 +83,33 @@ pub struct OnScore;
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 #[reflect(PartialEq, Debug, Default)]
-pub struct RunPicking;
+pub struct RunPicking {
+    /// The target entity to pick an action for, or [`None`] to pick for all entities.
+    pub entity: Option<Entity>,
+}
+
+impl RunPicking {
+    /// Creates a new [`RunPicking`] event for all entities.
+    #[must_use]
+    pub fn all() -> Self {
+        Self { entity: None }
+    }
+
+    /// Creates a new [`RunPicking`] event for a specific entity.
+    #[must_use]
+    pub fn entity(entity: Entity) -> Self {
+        Self { entity: Some(entity) }
+    }
+}
 
 /// Listen to this [`Event`] to handle picking an action for the target actor entity.
 #[derive(Event, Reflect)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(PartialEq, Debug, Default)]
-pub struct OnPick;
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[reflect(PartialEq, Debug)]
+pub struct OnPick {
+    /// The entity picking an action.
+    pub entity: Entity,
+}
 
 /// Listen to this [`Event`] to check which action was picked for the target actor entity.
 /// This [`Event`] is triggered by [`Picker`]s to indicate that an action has been picked for the target actor entity.
@@ -79,6 +119,8 @@ pub struct OnPick;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[reflect(PartialEq, Debug)]
 pub struct OnPicked {
+    /// The entity that picked an action.
+    pub entity: Entity,
     /// [`ComponentId`] of the action that was picked.
     pub action: ComponentId,
 }
@@ -88,14 +130,28 @@ pub struct OnPicked {
 ////////////////////////////////////////////////////////////
 
 /// Trigger this [`Event`] to request a specific action or the picked action to be initiated for the target actor entity.
-///
-/// This event SHOULD NOT be triggered without a target entity.
 #[derive(Event, Reflect)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(PartialEq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[reflect(PartialEq, Debug)]
 pub struct RequestAction {
+    /// The entity to request the action for.
+    pub entity: Entity,
     /// The [`ComponentId`] of the action that was requested, if any.
     pub action: Option<ComponentId>,
+}
+
+impl RequestAction {
+    /// Creates a new [`RequestAction`] event for the picked action.
+    #[must_use]
+    pub fn picked(entity: Entity) -> Self {
+        Self { entity, action: None }
+    }
+
+    /// Creates a new [`RequestAction`] event for a specific action.
+    #[must_use]
+    pub fn specific(entity: Entity, action: ComponentId) -> Self {
+        Self { entity, action: Some(action) }
+    }
 }
 
 /// This [`Event`] is triggered by action lifecycle to indicate that they have been initiated.
@@ -103,6 +159,8 @@ pub struct RequestAction {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[reflect(PartialEq, Debug)]
 pub struct OnActionInitiated {
+    /// The entity that initiated the action.
+    pub entity: Entity,
     /// [`ComponentId`] of the action that was initiated.
     pub action: ComponentId,
 }
@@ -115,6 +173,8 @@ pub struct OnActionInitiated {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[reflect(PartialEq, Debug)]
 pub struct OnActionEnded {
+    /// The entity whose action ended.
+    pub entity: Entity,
     /// [`ComponentId`] of the action that was finished.
     pub action: ComponentId,
     /// The reason the action was finished.
@@ -124,8 +184,9 @@ pub struct OnActionEnded {
 impl OnActionEnded {
     /// Creates a new [`Completed`][`ActionEndReason::Completed`] [`OnActionEnded`] event with the given action.
     #[must_use]
-    pub fn completed(action: ComponentId) -> Self {
+    pub fn completed(entity: Entity, action: ComponentId) -> Self {
         Self {
+            entity,
             action,
             reason: ActionEndReason::Completed,
         }
@@ -133,8 +194,9 @@ impl OnActionEnded {
 
     /// Creates a new [`Cancelled`][`ActionEndReason::Cancelled`] [`OnActionEnded`] event with the given action.
     #[must_use]
-    pub fn cancelled(action: ComponentId) -> Self {
+    pub fn cancelled(entity: Entity, action: ComponentId) -> Self {
         Self {
+            entity,
             action,
             reason: ActionEndReason::Cancelled,
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -44,14 +44,14 @@ use bevy::{ecs::component::ComponentId, prelude::*};
 /// ensuring that all children are scored before their parents.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(Component, PartialEq, Debug, Default)]
+#[reflect(PartialEq, Debug, Default)]
 pub struct RunScoring;
 
 /// This [`Event`] is listened to by scoring systems to calculate the score(s) for a given entity.
 /// DO NOT TRIGGER MANUALLY, trigger [`RunScoring`] instead.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(Component, PartialEq, Debug, Default)]
+#[reflect(PartialEq, Debug, Default)]
 pub struct OnScore;
 
 ////////////////////////////////////////////////////////////
@@ -62,13 +62,13 @@ pub struct OnScore;
 /// or all actor entities if no target is specified.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(Component, PartialEq, Debug, Default)]
+#[reflect(PartialEq, Debug, Default)]
 pub struct RunPicking;
 
 /// Listen to this [`Event`] to handle picking an action for the target actor entity.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(Component, PartialEq, Debug, Default)]
+#[reflect(PartialEq, Debug, Default)]
 pub struct OnPick;
 
 /// Listen to this [`Event`] to check which action was picked for the target actor entity.
@@ -77,7 +77,7 @@ pub struct OnPick;
 /// [`Picker`]: crate::picking::Picker
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[reflect(Component, PartialEq, Debug)]
+#[reflect(PartialEq, Debug)]
 pub struct OnPicked {
     /// [`ComponentId`] of the action that was picked.
     pub action: ComponentId,
@@ -92,7 +92,7 @@ pub struct OnPicked {
 /// This event SHOULD NOT be triggered without a target entity.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-#[reflect(Component, PartialEq, Debug, Default)]
+#[reflect(PartialEq, Debug, Default)]
 pub struct RequestAction {
     /// The [`ComponentId`] of the action that was requested, if any.
     pub action: Option<ComponentId>,
@@ -101,7 +101,7 @@ pub struct RequestAction {
 /// This [`Event`] is triggered by action lifecycle to indicate that they have been initiated.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[reflect(Component, PartialEq, Debug)]
+#[reflect(PartialEq, Debug)]
 pub struct OnActionInitiated {
     /// [`ComponentId`] of the action that was initiated.
     pub action: ComponentId,
@@ -113,7 +113,7 @@ pub struct OnActionInitiated {
 /// An action will be cancelled if a different action is [requested][`RequestAction`] before it completes.
 #[derive(Event, Reflect)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[reflect(Component, PartialEq, Debug)]
+#[reflect(PartialEq, Debug)]
 pub struct OnActionEnded {
     /// [`ComponentId`] of the action that was finished.
     pub action: ComponentId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,19 +232,19 @@ pub mod scoring;
 pub mod prelude {
     //! Re-exports important traits and types.
     pub use crate::{
+        ObservedUtilityPlugins,
         acting::{
-            on_action_ended_remove, on_action_initiated_insert_default, on_action_initiated_insert_from_resource,
-            CurrentAction,
+            CurrentAction, on_action_ended_remove, on_action_initiated_insert_default,
+            on_action_initiated_insert_from_resource,
         },
         ecs::{AncestorQuery, TargetedAction},
         event::{ActionEndReason, OnActionEnded, OnActionInitiated, OnPick, OnPicked, OnScore, RunPicking, RunScoring},
         picking::{FirstToScore, Highest, Picker},
         scoring::{
-            score_ancestor, AllOrNothing, Evaluated, Evaluator, FixedScore, LinearEvaluator, Measure, Measured,
-            PowerEvaluator, Product, Score, SigmoidEvaluator, Sum, Weighted, WeightedMax, WeightedProduct, WeightedRMS,
-            WeightedSum, Winning,
+            AllOrNothing, Evaluated, Evaluator, FixedScore, LinearEvaluator, Measure, Measured, PowerEvaluator,
+            Product, Score, SigmoidEvaluator, Sum, Weighted, WeightedMax, WeightedProduct, WeightedRMS, WeightedSum,
+            Winning, score_ancestor,
         },
-        ObservedUtilityPlugins,
     };
 
     #[cfg(feature = "rand")]

--- a/src/picking/first_to_score.rs
+++ b/src/picking/first_to_score.rs
@@ -104,7 +104,8 @@ impl FirstToScore {
         ) {
             for (score_entity, score) in scores.iter_many(children) {
                 if *score >= settings.threshold() {
-                    picker.pick(Some(score_entity));
+                    let action = picker.pick(Some(score_entity));
+                    commands.trigger(OnPicked { entity: target, action });
                     return;
                 }
             }

--- a/src/picking/first_to_score.rs
+++ b/src/picking/first_to_score.rs
@@ -125,9 +125,10 @@ impl FirstToScore {
 
 impl Component for FirstToScore {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct FirstToScoreObserverSpawned;
 

--- a/src/picking/highest.rs
+++ b/src/picking/highest.rs
@@ -104,9 +104,10 @@ impl Highest {
 
 impl Component for Highest {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct HighestObserverSpawned;
 

--- a/src/picking/random.rs
+++ b/src/picking/random.rs
@@ -2,7 +2,7 @@ use bevy::{
     ecs::component::{ComponentHooks, StorageType},
     prelude::*,
 };
-use rand::{seq::IteratorRandom, RngCore};
+use rand::{RngCore, seq::IteratorRandom};
 
 use crate::{
     ecs::{CommandsExt, TriggerGetEntity},
@@ -109,6 +109,7 @@ impl<R: RngCore + Send + Sync + 'static> From<R> for PickRandom {
 
 impl Component for PickRandom {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
         hooks.on_add(|mut world, _entity, _component| {

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -87,7 +87,7 @@ impl ScoringPlugin {
     pub fn run_scoring_post_order_dfs(
         trigger: Trigger<RunScoring>,
         mut commands: Commands,
-        scoreable_roots: Query<(Entity, Option<&Parent>), With<Score>>,
+        scoreable_roots: Query<(Entity, Option<&ChildOf>), With<Score>>,
         root_parents: Query<(), Without<Score>>,
         mut dfs: DFSPostTraversal<With<Score>>,
     ) {
@@ -107,7 +107,7 @@ impl ScoringPlugin {
             // Find all score entities that have no parents at all, or whose parents are not score entities
             let roots = scoreable_roots.iter().filter_map(|(entity, parent)| {
                 if let Some(parent) = parent {
-                    if root_parents.contains(**parent) {
+                    if root_parents.contains(parent.parent()) {
                         Some(entity)
                     } else {
                         None
@@ -370,7 +370,7 @@ pub fn score_ancestor<T: Component, ScoreMarker: Component>(
 ) where
     for<'a> &'a T: Into<Score>,
 {
-    let scorer = trigger.entity();
+    let scorer = trigger.target();
     let Ok(mut score) = scores.get_mut(scorer) else {
         return;
     };
@@ -389,7 +389,6 @@ mod tests {
     use bevy::{
         app::App,
         ecs::observer::ObserverState,
-        hierarchy::{BuildChildren, ChildBuild},
         prelude::{With, World},
     };
 

--- a/src/scoring/all_or_nothing.rs
+++ b/src/scoring/all_or_nothing.rs
@@ -58,7 +58,7 @@ impl AllOrNothing {
 
     /// [`Observer`] for [`AllOrNothing`] [`Score`] entities that scores based on all child [`Score`] entities.
     fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &AllOrNothing)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.entity()) else {
+        let Ok((children, settings)) = target.get(trigger.target()) else {
             // The entity is not scoring for all-or-nothing.
             return;
         };
@@ -73,7 +73,7 @@ impl AllOrNothing {
             sum += child_score.get();
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.entity()) else {
+        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
             // The entity is not scoring.
             return;
         };
@@ -84,9 +84,10 @@ impl AllOrNothing {
 
 impl Component for AllOrNothing {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct AllOrNothingObserverSpawned;
 

--- a/src/scoring/all_or_nothing.rs
+++ b/src/scoring/all_or_nothing.rs
@@ -1,9 +1,13 @@
 use bevy::{
-    ecs::component::{ComponentHooks, StorageType},
+    ecs::{
+        component::StorageType,
+        lifecycle::{ComponentHook, HookContext},
+        world::DeferredWorld,
+    },
     prelude::*,
 };
 
-use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
+use crate::{ecs::DeferredWorldExt, event::OnScore, scoring::Score};
 
 /// [`Score`] [`Component`] that scores all-or-nothing based on the sum of its child [`Score`] entities.
 ///
@@ -25,7 +29,7 @@ use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
 ///         parent.spawn((FixedScore::new(0.3), Score::default()));
 ///     })
 /// #   .id();
-/// # commands.trigger_targets(RunScoring, scorer);
+/// # commands.trigger(RunScoring::entity(scorer));
 /// # world.flush();
 /// # assert_eq!(world.get::<Score>(scorer).unwrap().get(), 0.0);
 /// ```
@@ -57,8 +61,9 @@ impl AllOrNothing {
     }
 
     /// [`Observer`] for [`AllOrNothing`] [`Score`] entities that scores based on all child [`Score`] entities.
-    fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &AllOrNothing)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.target()) else {
+    fn observer(trigger: On<OnScore>, target: Query<(&Children, &AllOrNothing)>, mut scores: Query<&mut Score>) {
+        let entity = trigger.event().entity;
+        let Ok((children, settings)) = target.get(entity) else {
             // The entity is not scoring for all-or-nothing.
             return;
         };
@@ -73,7 +78,7 @@ impl AllOrNothing {
             sum += child_score.get();
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
+        let Ok(mut actor_score) = scores.get_mut(entity) else {
             // The entity is not scoring.
             return;
         };
@@ -86,15 +91,12 @@ impl Component for AllOrNothing {
     const STORAGE_TYPE: StorageType = StorageType::Table;
     type Mutability = bevy::ecs::component::Immutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|mut world: DeferredWorld, _context: HookContext| {
             #[derive(Resource, Default)]
             struct AllOrNothingObserverSpawned;
 
-            world
-                .commands()
-                .once::<AllOrNothingObserverSpawned>()
-                .observe(Self::observer);
-        });
+            world.once::<AllOrNothingObserverSpawned>().observe(Self::observer);
+        })
     }
 }

--- a/src/scoring/evaluator.rs
+++ b/src/scoring/evaluator.rs
@@ -133,6 +133,11 @@ impl LinearEvaluator {
         }
     }
 
+    /// A linear evaluator that inverts values in the 0.0..=1.0 range.
+    pub fn not() -> Self {
+        Self::from_range(1.0, 0.0)
+    }
+
     /// Creates a linear evaluator with the given range.
     #[must_use]
     pub fn from_range(min: f32, max: f32) -> Self {

--- a/src/scoring/evaluator.rs
+++ b/src/scoring/evaluator.rs
@@ -134,6 +134,7 @@ impl LinearEvaluator {
     }
 
     /// A linear evaluator that inverts values in the 0.0..=1.0 range.
+    #[must_use]
     pub fn not() -> Self {
         Self::from_range(1.0, 0.0)
     }

--- a/src/scoring/evaluator.rs
+++ b/src/scoring/evaluator.rs
@@ -70,7 +70,7 @@ impl Evaluated {
 
     /// [`Observer`] for [`Evaluated`] [`Score`] entities that scores a single child [`Score`] entity.
     fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &Evaluated)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.entity()) else {
+        let Ok((children, settings)) = target.get(trigger.target()) else {
             // The entity is not scoring for evaluated.
             return;
         };
@@ -81,7 +81,7 @@ impl Evaluated {
             };
             let value = settings.evaluate(child_score.get());
 
-            let Ok(mut target_score) = scores.get_mut(trigger.entity()) else {
+            let Ok(mut target_score) = scores.get_mut(trigger.target()) else {
                 return;
             };
             target_score.set(value);
@@ -91,9 +91,10 @@ impl Evaluated {
 
 impl Component for Evaluated {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct EvaluatedObserverSpawned;
 

--- a/src/scoring/fixed.rs
+++ b/src/scoring/fixed.rs
@@ -52,7 +52,7 @@ impl FixedScore {
 
     /// [`Observer`] for [`FixedScore`] [`Score`] entities that scores itself.
     fn observer(trigger: Trigger<OnScore>, mut target: Query<(&mut Score, &FixedScore)>) {
-        let Ok((mut actor_score, settings)) = target.get_mut(trigger.entity()) else {
+        let Ok((mut actor_score, settings)) = target.get_mut(trigger.target()) else {
             // The entity is not scoring for fixed.
             return;
         };
@@ -63,9 +63,10 @@ impl FixedScore {
 
 impl Component for FixedScore {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct FixedScoreObserverSpawned;
 

--- a/src/scoring/measured.rs
+++ b/src/scoring/measured.rs
@@ -76,7 +76,7 @@ impl Measured {
         target: Query<(&Children, &Measured)>,
         mut scores: Query<(&mut Score, Option<&Weighted>)>,
     ) {
-        let Ok((children, settings)) = target.get(trigger.entity()) else {
+        let Ok((children, settings)) = target.get(trigger.target()) else {
             // The entity is not scoring for measured.
             return;
         };
@@ -89,7 +89,7 @@ impl Measured {
 
         let result = settings.calculate(inputs);
 
-        let Ok((mut actor_score, _)) = scores.get_mut(trigger.entity()) else {
+        let Ok((mut actor_score, _)) = scores.get_mut(trigger.target()) else {
             // The entity is not scoring.
             return;
         };
@@ -100,9 +100,10 @@ impl Measured {
 
 impl Component for Measured {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct MeasuredObserverSpawned;
 

--- a/src/scoring/product.rs
+++ b/src/scoring/product.rs
@@ -69,7 +69,7 @@ impl Product {
 
     /// [`Observer`] for [`Product`] [`Score`] entities that scores based on all child [`Score`] entities.
     fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &Product)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.entity()) else {
+        let Ok((children, settings)) = target.get(trigger.target()) else {
             // The entity is not scoring for product.
             return;
         };
@@ -92,7 +92,7 @@ impl Product {
             product = 0.;
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.entity()) else {
+        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
             // The entity is not scoring.
             return;
         };
@@ -103,9 +103,10 @@ impl Product {
 
 impl Component for Product {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct ProductObserverSpawned;
 

--- a/src/scoring/product.rs
+++ b/src/scoring/product.rs
@@ -1,9 +1,13 @@
 use bevy::{
-    ecs::component::{ComponentHooks, StorageType},
+    ecs::{
+        component::StorageType,
+        lifecycle::{ComponentHook, HookContext},
+        world::DeferredWorld,
+    },
     prelude::*,
 };
 
-use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
+use crate::{ecs::DeferredWorldExt, event::OnScore, scoring::Score};
 
 /// [`Score`] [`Component`] that scores the product of all child [`Score`] entities.
 ///
@@ -26,7 +30,7 @@ use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
 ///         parent.spawn((FixedScore::new(0.3), Score::default()));
 ///     })
 /// #   .id();
-/// # commands.trigger_targets(RunScoring, scorer);
+/// # commands.trigger(RunScoring::entity(scorer));
 /// # world.flush();
 /// # assert_relative_eq!(world.get::<Score>(scorer).unwrap().get(), 0.21);
 /// ```
@@ -68,8 +72,9 @@ impl Product {
     }
 
     /// [`Observer`] for [`Product`] [`Score`] entities that scores based on all child [`Score`] entities.
-    fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &Product)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.target()) else {
+    fn observer(trigger: On<OnScore>, target: Query<(&Children, &Product)>, mut scores: Query<&mut Score>) {
+        let entity = trigger.event().entity;
+        let Ok((children, settings)) = target.get(entity) else {
             // The entity is not scoring for product.
             return;
         };
@@ -92,7 +97,7 @@ impl Product {
             product = 0.;
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
+        let Ok(mut actor_score) = scores.get_mut(entity) else {
             // The entity is not scoring.
             return;
         };
@@ -105,15 +110,12 @@ impl Component for Product {
     const STORAGE_TYPE: StorageType = StorageType::Table;
     type Mutability = bevy::ecs::component::Immutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|mut world: DeferredWorld, _context: HookContext| {
             #[derive(Resource, Default)]
             struct ProductObserverSpawned;
 
-            world
-                .commands()
-                .once::<ProductObserverSpawned>()
-                .observe(Self::observer);
-        });
+            world.once::<ProductObserverSpawned>().observe(Self::observer);
+        })
     }
 }

--- a/src/scoring/random.rs
+++ b/src/scoring/random.rs
@@ -70,7 +70,7 @@ impl RandomScore {
     }
 
     fn observer(trigger: Trigger<OnScore>, mut target: Query<(&mut Score, &mut RandomScore)>) {
-        let Ok((mut actor_score, mut settings)) = target.get_mut(trigger.entity()) else {
+        let Ok((mut actor_score, mut settings)) = target.get_mut(trigger.target()) else {
             // The entity is not scoring for random.
             return;
         };
@@ -85,9 +85,10 @@ impl RandomScore {
 
 impl Component for RandomScore {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct RandomScoreObserverSpawned;
 

--- a/src/scoring/sum.rs
+++ b/src/scoring/sum.rs
@@ -58,7 +58,7 @@ impl Sum {
 
     /// [`Observer`] for [`Sum`] [`Score`] entities that scores based on all child [`Score`] entities.
     fn observer(trigger: Trigger<OnScore>, target: Query<(&Children, &Sum)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = target.get(trigger.entity()) else {
+        let Ok((children, settings)) = target.get(trigger.target()) else {
             // The entity is not scoring for sum.
             return;
         };
@@ -73,7 +73,7 @@ impl Sum {
             sum = 0.;
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.entity()) else {
+        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
             // The entity is not scoring.
             return;
         };
@@ -84,9 +84,10 @@ impl Sum {
 
 impl Component for Sum {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct SumObserverSpawned;
 

--- a/src/scoring/winning.rs
+++ b/src/scoring/winning.rs
@@ -58,7 +58,7 @@ impl Winning {
 
     /// [`Observer`] for [`Winning`] [`Score`] entities that scores based on all child [`Score`] entities.
     fn observer(trigger: Trigger<OnScore>, actor: Query<(&Children, &Winning)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = actor.get(trigger.entity()) else {
+        let Ok((children, settings)) = actor.get(trigger.target()) else {
             // The entity is not scoring for winning.
             return;
         };
@@ -74,7 +74,7 @@ impl Winning {
             max = 0.;
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.entity()) else {
+        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
             // The entity is not scoring.
             return;
         };
@@ -85,9 +85,10 @@ impl Winning {
 
 impl Component for Winning {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    type Mutability = bevy::ecs::component::Immutable;
 
     fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity, _component| {
+        hooks.on_add(|mut world, _entity| {
             #[derive(Resource, Default)]
             struct WinningObserverSpawned;
 

--- a/src/scoring/winning.rs
+++ b/src/scoring/winning.rs
@@ -1,9 +1,13 @@
 use bevy::{
-    ecs::component::{ComponentHooks, StorageType},
+    ecs::{
+        component::StorageType,
+        lifecycle::{ComponentHook, HookContext},
+        world::DeferredWorld,
+    },
     prelude::*,
 };
 
-use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
+use crate::{ecs::DeferredWorldExt, event::OnScore, scoring::Score};
 
 /// [`Score`] [`Component`] that scores based on the maximum of its child [`Score`] entities.
 ///
@@ -25,7 +29,7 @@ use crate::{ecs::CommandsExt, event::OnScore, scoring::Score};
 ///         parent.spawn((FixedScore::new(0.3), Score::default()));
 ///     })
 /// #   .id();
-/// # commands.trigger_targets(RunScoring, scorer);
+/// # commands.trigger(RunScoring::entity(scorer));
 /// # world.flush();
 /// # assert_eq!(world.get::<Score>(scorer).unwrap().get(), 0.7);
 /// ```
@@ -57,8 +61,9 @@ impl Winning {
     }
 
     /// [`Observer`] for [`Winning`] [`Score`] entities that scores based on all child [`Score`] entities.
-    fn observer(trigger: Trigger<OnScore>, actor: Query<(&Children, &Winning)>, mut scores: Query<&mut Score>) {
-        let Ok((children, settings)) = actor.get(trigger.target()) else {
+    fn observer(trigger: On<OnScore>, actor: Query<(&Children, &Winning)>, mut scores: Query<&mut Score>) {
+        let entity = trigger.event().entity;
+        let Ok((children, settings)) = actor.get(entity) else {
             // The entity is not scoring for winning.
             return;
         };
@@ -74,7 +79,7 @@ impl Winning {
             max = 0.;
         }
 
-        let Ok(mut actor_score) = scores.get_mut(trigger.target()) else {
+        let Ok(mut actor_score) = scores.get_mut(entity) else {
             // The entity is not scoring.
             return;
         };
@@ -87,15 +92,12 @@ impl Component for Winning {
     const STORAGE_TYPE: StorageType = StorageType::Table;
     type Mutability = bevy::ecs::component::Immutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, _entity| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|mut world: DeferredWorld, _context: HookContext| {
             #[derive(Resource, Default)]
             struct WinningObserverSpawned;
 
-            world
-                .commands()
-                .once::<WinningObserverSpawned>()
-                .observe(Self::observer);
-        });
+            world.once::<WinningObserverSpawned>().observe(Self::observer);
+        })
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,723 @@
+//! Comprehensive integration tests for bevy_observed_utility
+//! Tests the complete observer and trigger architecture after Bevy 0.17 migration
+
+use approx::assert_relative_eq;
+use bevy::{ecs::component::ComponentId, prelude::*};
+use bevy_observed_utility::prelude::*;
+
+/// Test that the basic scoring lifecycle works with the new trigger architecture
+#[test]
+fn test_scoring_lifecycle() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    let world = app.world_mut();
+
+    // Create a simple fixed score entity
+    let mut commands = world.commands();
+    let scorer = commands.spawn((Score::default(), FixedScore::new(0.75))).id();
+    world.flush();
+
+    // Trigger scoring
+    world.commands().trigger(RunScoring::entity(scorer));
+    world.flush();
+
+    // Verify the score was calculated correctly
+    assert_eq!(
+        0.75,
+        world.get::<Score>(scorer).unwrap().get(),
+        "Score should be set to 0.75 via the observer"
+    );
+}
+
+/// Test that scoring works for all entities when using RunScoring::all()
+#[test]
+fn test_scoring_all_entities() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    let world = app.world_mut();
+
+    // Create multiple score entities
+    let mut commands = world.commands();
+    let scorer1 = commands.spawn((Score::default(), FixedScore::new(0.5))).id();
+    let scorer2 = commands.spawn((Score::default(), FixedScore::new(0.8))).id();
+    let scorer3 = commands.spawn((Score::default(), FixedScore::new(0.3))).id();
+    world.flush();
+
+    // Trigger scoring for all
+    world.commands().trigger(RunScoring::all());
+    world.flush();
+
+    // Verify all scores were calculated
+    assert_eq!(0.5, world.get::<Score>(scorer1).unwrap().get());
+    assert_eq!(0.8, world.get::<Score>(scorer2).unwrap().get());
+    assert_eq!(0.3, world.get::<Score>(scorer3).unwrap().get());
+}
+
+/// Test hierarchical scoring with parent-child relationships
+#[test]
+fn test_hierarchical_scoring() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    let world = app.world_mut();
+
+    let mut commands = world.commands();
+    let parent = commands
+        .spawn((Score::default(), Sum::default()))
+        .with_children(|parent| {
+            parent.spawn((Score::default(), FixedScore::new(0.3)));
+            parent.spawn((Score::default(), FixedScore::new(0.4)));
+        })
+        .id();
+    world.flush();
+
+    // Trigger scoring on the parent (should score children first due to post-order traversal)
+    world.commands().trigger(RunScoring::entity(parent));
+    world.flush();
+
+    // Parent should have the sum of children
+    assert_relative_eq!(
+        0.7,
+        world.get::<Score>(parent).unwrap().get(),
+        epsilon = 0.0001
+    );
+}
+
+/// Test the picking lifecycle with FirstToScore strategy
+#[test]
+fn test_picking_first_to_score() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    let world = app.world_mut();
+
+    let my_action = world.register_component::<MyAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let scorer = commands.spawn((Score::new(0.6), MyMarker)).id();
+
+    let actor = commands
+        .spawn((
+            Picker::new(idle_action).with(scorer, my_action),
+            FirstToScore::new(0.5),
+        ))
+        .add_child(scorer)
+        .id();
+    world.flush();
+
+    // Run picking
+    world.commands().trigger(RunPicking::entity(actor));
+    world.flush();
+
+    // Since score (0.6) is above threshold (0.5), my_action should be picked
+    assert_eq!(my_action, world.get::<Picker>(actor).unwrap().picked);
+}
+
+/// Test the picking lifecycle with Highest strategy
+#[test]
+fn test_picking_highest() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    let world = app.world_mut();
+
+    let action1 = world.register_component::<Action1>();
+    let action2 = world.register_component::<Action2>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let scorer1 = commands.spawn((Score::new(0.3), MyMarker)).id();
+    let scorer2 = commands.spawn((Score::new(0.8), MyMarker)).id();
+
+    let actor = commands
+        .spawn((
+            Picker::new(idle_action).with(scorer1, action1).with(scorer2, action2),
+            Highest,
+        ))
+        .add_children(&[scorer1, scorer2])
+        .id();
+    world.flush();
+
+    // Run picking
+    world.commands().trigger(RunPicking::entity(actor));
+    world.flush();
+
+    // action2 should be picked since scorer2 has the highest score (0.8)
+    assert_eq!(action2, world.get::<Picker>(actor).unwrap().picked);
+}
+
+/// Test action lifecycle: initiation, execution, and completion
+#[test]
+fn test_action_lifecycle() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    // Add observer to handle action initiation
+    app.add_observer(on_action_initiated_insert_default::<TestAction>);
+    app.add_observer(on_action_ended_remove::<TestAction>);
+
+    let world = app.world_mut();
+
+    let action_id = world.register_component::<TestAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let actor = commands.spawn((Picker::new(idle_action), CurrentAction(idle_action))).id();
+    world.flush();
+
+    // Request the action
+    world.commands().trigger(RequestAction::specific(actor, action_id));
+    world.flush();
+
+    // Verify action was initiated and component was inserted
+    assert!(
+        world.get::<TestAction>(actor).is_some(),
+        "TestAction component should be inserted on actor"
+    );
+    assert_eq!(
+        action_id,
+        world.get::<CurrentAction>(actor).unwrap().0,
+        "CurrentAction should be updated to the requested action"
+    );
+
+    // Complete the action
+    world.commands().trigger(OnActionEnded::completed(actor, action_id));
+    world.flush();
+
+    // Verify action was removed
+    assert!(
+        world.get::<TestAction>(actor).is_none(),
+        "TestAction component should be removed after completion"
+    );
+}
+
+/// Test action cancellation when switching actions
+#[test]
+fn test_action_cancellation() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    // Create custom observers that check the action component id
+    app.add_observer(
+        |trigger: On<OnActionInitiated>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            let action1_id = world.component_id::<Action1>().unwrap();
+            if action == action1_id {
+                commands.entity(actor).insert(Action1::default());
+            }
+        },
+    );
+    app.add_observer(
+        |trigger: On<OnActionInitiated>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            let action2_id = world.component_id::<Action2>().unwrap();
+            if action == action2_id {
+                commands.entity(actor).insert(Action2::default());
+            }
+        },
+    );
+    app.add_observer(
+        |trigger: On<OnActionEnded>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            let action1_id = world.component_id::<Action1>().unwrap();
+            if action == action1_id {
+                commands.entity(actor).remove::<Action1>();
+            }
+        },
+    );
+    app.add_observer(
+        |trigger: On<OnActionEnded>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            let action2_id = world.component_id::<Action2>().unwrap();
+            if action == action2_id {
+                commands.entity(actor).remove::<Action2>();
+            }
+        },
+    );
+
+    let world = app.world_mut();
+
+    let action1_id = world.register_component::<Action1>();
+    let action2_id = world.register_component::<Action2>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let actor = commands.spawn((Picker::new(idle_action), CurrentAction(idle_action))).id();
+    world.flush();
+
+    // Start action1
+    world.commands().trigger(RequestAction::specific(actor, action1_id));
+    world.flush();
+
+    assert!(world.get::<Action1>(actor).is_some(), "Action1 should be active");
+    assert_eq!(action1_id, world.get::<CurrentAction>(actor).unwrap().0);
+
+    // Switch to action2 (should cancel action1)
+    world.commands().trigger(RequestAction::specific(actor, action2_id));
+    world.flush();
+
+    assert!(world.get::<Action1>(actor).is_none(), "Action1 should be removed/cancelled");
+    assert!(world.get::<Action2>(actor).is_some(), "Action2 should now be active");
+    assert_eq!(
+        action2_id,
+        world.get::<CurrentAction>(actor).unwrap().0,
+        "CurrentAction should be updated to action2"
+    );
+}
+
+/// Test the complete utility AI lifecycle: score -> pick -> act
+#[test]
+fn test_complete_utility_ai_lifecycle() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    app.add_observer(on_action_initiated_insert_default::<DrinkAction>);
+    app.add_observer(on_action_ended_remove::<DrinkAction>);
+
+    let world = app.world_mut();
+
+    let drink_action = world.register_component::<DrinkAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+
+    // Create a thirst scorer
+    let thirst_scorer = commands.spawn((Score::new(0.8), ThirstMarker)).id();
+
+    // Create an actor with a picker
+    let actor = commands
+        .spawn((
+            Picker::new(idle_action).with(thirst_scorer, drink_action),
+            FirstToScore::new(0.5),
+            CurrentAction(idle_action),
+        ))
+        .add_child(thirst_scorer)
+        .id();
+    world.flush();
+
+    // Run the complete lifecycle
+    // 1. Score
+    world.commands().trigger(RunScoring::entity(thirst_scorer));
+    world.flush();
+
+    // Verify scoring worked
+    assert_eq!(0.8, world.get::<Score>(thirst_scorer).unwrap().get());
+
+    // 2. Pick
+    world.commands().trigger(RunPicking::entity(actor));
+    world.flush();
+
+    // Verify picking worked - should pick drink_action since score (0.8) > threshold (0.5)
+    assert_eq!(drink_action, world.get::<Picker>(actor).unwrap().picked);
+
+    // 3. Act - request the picked action
+    world.commands().trigger(RequestAction::picked(actor));
+    world.flush();
+
+    // Verify action was initiated
+    assert!(world.get::<DrinkAction>(actor).is_some(), "DrinkAction should be active");
+    assert_eq!(drink_action, world.get::<CurrentAction>(actor).unwrap().0);
+}
+
+/// Test that OnScore events are triggered with correct entity information
+#[test]
+fn test_on_score_event_contains_entity() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    // Track which entities received OnScore events
+    #[derive(Resource, Default)]
+    struct ScoredEntities(Vec<Entity>);
+
+    app.insert_resource(ScoredEntities::default());
+
+    // Add an observer to capture OnScore events
+    app.add_observer(
+        |trigger: On<OnScore>, mut scored: ResMut<ScoredEntities>| {
+            scored.0.push(trigger.event().entity);
+        },
+    );
+
+    let world = app.world_mut();
+
+    let mut commands = world.commands();
+    let scorer = commands.spawn((Score::default(), FixedScore::new(0.5))).id();
+    world.flush();
+
+    // Trigger scoring
+    world.commands().trigger(RunScoring::entity(scorer));
+    world.flush();
+
+    // Verify the event was triggered with the correct entity
+    let scored = world.resource::<ScoredEntities>();
+    assert!(
+        scored.0.contains(&scorer),
+        "OnScore event should have been triggered with the scorer entity"
+    );
+}
+
+/// Test that OnPicked events contain correct entity and action information
+#[test]
+fn test_on_picked_event_contains_entity_and_action() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    #[derive(Resource, Default)]
+    struct PickedActions(Vec<(Entity, ComponentId)>);
+
+    app.insert_resource(PickedActions::default());
+
+    // Add an observer to capture OnPicked events
+    app.add_observer(
+        |trigger: On<OnPicked>, mut picked: ResMut<PickedActions>| {
+            picked.0.push((trigger.event().entity, trigger.event().action));
+        },
+    );
+
+    let world = app.world_mut();
+
+    let my_action = world.register_component::<MyAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let scorer = commands.spawn((Score::new(0.8), MyMarker)).id();
+    let actor = commands
+        .spawn((
+            Picker::new(idle_action).with(scorer, my_action),
+            FirstToScore::new(0.5),
+        ))
+        .add_child(scorer)
+        .id();
+    world.flush();
+
+    // Run picking
+    world.commands().trigger(RunPicking::entity(actor));
+    world.flush();
+
+    // Verify the OnPicked event was triggered with correct entity and action
+    let picked = world.resource::<PickedActions>();
+    assert_eq!(1, picked.0.len(), "Should have one picked action");
+    assert_eq!(actor, picked.0[0].0, "Entity should match the actor");
+    assert_eq!(my_action, picked.0[0].1, "Action should be my_action");
+}
+
+/// Test that OnActionInitiated events contain correct entity and action information
+#[test]
+fn test_on_action_initiated_event() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    #[derive(Resource, Default)]
+    struct InitiatedActions(Vec<(Entity, ComponentId)>);
+
+    app.insert_resource(InitiatedActions::default());
+
+    // Add an observer to capture OnActionInitiated events
+    app.add_observer(
+        |trigger: On<OnActionInitiated>, mut initiated: ResMut<InitiatedActions>| {
+            initiated.0.push((trigger.event().entity, trigger.event().action));
+        },
+    );
+
+    let world = app.world_mut();
+
+    let my_action = world.register_component::<MyAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let actor = commands.spawn((Picker::new(idle_action), CurrentAction(idle_action))).id();
+    world.flush();
+
+    // Request an action
+    world.commands().trigger(RequestAction::specific(actor, my_action));
+    world.flush();
+
+    // Verify the OnActionInitiated event was triggered
+    let initiated = world.resource::<InitiatedActions>();
+    assert_eq!(1, initiated.0.len(), "Should have one initiated action");
+    assert_eq!(actor, initiated.0[0].0, "Entity should match the actor");
+    assert_eq!(my_action, initiated.0[0].1, "Action should be my_action");
+}
+
+/// Test that OnActionEnded events contain correct entity, action, and reason information
+#[test]
+fn test_on_action_ended_event() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    #[derive(Resource, Default)]
+    struct EndedActions(Vec<(Entity, ComponentId, ActionEndReason)>);
+
+    app.insert_resource(EndedActions::default());
+
+    // Add an observer to capture OnActionEnded events
+    app.add_observer(
+        |trigger: On<OnActionEnded>, mut ended: ResMut<EndedActions>| {
+            ended
+                .0
+                .push((trigger.event().entity, trigger.event().action, trigger.event().reason));
+        },
+    );
+
+    app.add_observer(on_action_initiated_insert_default::<TestAction>);
+    app.add_observer(on_action_ended_remove::<TestAction>);
+
+    let world = app.world_mut();
+
+    let my_action = world.register_component::<TestAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let actor = commands.spawn((Picker::new(idle_action), CurrentAction(idle_action))).id();
+    world.flush();
+
+    // Start an action
+    world.commands().trigger(RequestAction::specific(actor, my_action));
+    world.flush();
+
+    // Complete the action
+    world.commands().trigger(OnActionEnded::completed(actor, my_action));
+    world.flush();
+
+    // Verify the OnActionEnded event was triggered with Completed reason
+    let ended = world.resource::<EndedActions>();
+    // Filter to just the my_action events with Completed reason
+    let my_action_completed: Vec<_> = ended
+        .0
+        .iter()
+        .filter(|(_, a, r)| *a == my_action && *r == ActionEndReason::Completed)
+        .collect();
+
+    assert!(
+        !my_action_completed.is_empty(),
+        "Should have at least one completed my_action event"
+    );
+    assert_eq!(actor, my_action_completed[0].0, "Entity should match the actor");
+    assert_eq!(my_action, my_action_completed[0].1, "Action should be my_action");
+    assert_eq!(
+        ActionEndReason::Completed,
+        my_action_completed[0].2,
+        "Reason should be Completed"
+    );
+}
+
+/// Test action cancellation event
+#[test]
+fn test_on_action_cancelled_event() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    #[derive(Resource, Default)]
+    struct EndedActions(Vec<(Entity, ComponentId, ActionEndReason)>);
+
+    app.insert_resource(EndedActions::default());
+
+    app.add_observer(
+        |trigger: On<OnActionEnded>, mut ended: ResMut<EndedActions>| {
+            ended
+                .0
+                .push((trigger.event().entity, trigger.event().action, trigger.event().reason));
+        },
+    );
+
+    app.add_observer(on_action_initiated_insert_default::<Action1>);
+    app.add_observer(on_action_initiated_insert_default::<Action2>);
+    app.add_observer(on_action_ended_remove::<Action1>);
+    app.add_observer(on_action_ended_remove::<Action2>);
+
+    let world = app.world_mut();
+
+    let action1 = world.register_component::<Action1>();
+    let action2 = world.register_component::<Action2>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let actor = commands.spawn((Picker::new(idle_action), CurrentAction(idle_action))).id();
+    world.flush();
+
+    // Start action1
+    world.commands().trigger(RequestAction::specific(actor, action1));
+    world.flush();
+
+    // Switch to action2 (cancels action1)
+    world.commands().trigger(RequestAction::specific(actor, action2));
+    world.flush();
+
+    // Verify action1 was cancelled
+    let ended = world.resource::<EndedActions>();
+    assert!(
+        ended.0.iter().any(|(e, a, r)| *e == actor && *a == action1 && *r == ActionEndReason::Cancelled),
+        "Action1 should have been cancelled"
+    );
+}
+
+/// Test real-time lifecycle automation
+/// This test verifies that the RealTime plugin is properly configured and can execute
+/// the complete utility AI lifecycle (score -> pick -> act) when triggered manually.
+#[test]
+fn test_realtime_lifecycle() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::RealTime);
+
+    // Add custom observers that check the action component id
+    app.add_observer(
+        |trigger: On<OnActionInitiated>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            if let Some(drink_action_id) = world.component_id::<DrinkAction>() {
+                if action == drink_action_id {
+                    commands.entity(actor).insert(DrinkAction::default());
+                }
+            }
+        },
+    );
+    app.add_observer(
+        |trigger: On<OnActionEnded>, mut commands: Commands, world: &World| {
+            let actor = trigger.event().entity;
+            let action = trigger.event().action;
+            if let Some(drink_action_id) = world.component_id::<DrinkAction>() {
+                if action == drink_action_id {
+                    commands.entity(actor).remove::<DrinkAction>();
+                }
+            }
+        },
+    );
+
+    let world = app.world_mut();
+
+    let drink_action = world.register_component::<DrinkAction>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+    let thirst_scorer = commands.spawn((Score::default(), FixedScore::new(0.9), ThirstMarker)).id();
+    let actor = commands
+        .spawn((
+            Picker::new(idle_action).with(thirst_scorer, drink_action),
+            FirstToScore::new(0.5),
+            CurrentAction(idle_action),
+        ))
+        .add_child(thirst_scorer)
+        .id();
+    world.flush();
+
+    // Manually trigger the lifecycle to test it works
+    // (In real-time mode, this would happen automatically in FixedPostUpdate)
+    world.commands().trigger(RunScoring::all());
+    world.commands().trigger(RunPicking::all());
+    world.flush();
+
+    // Check the score was updated
+    let score = world.get::<Score>(thirst_scorer).unwrap().get();
+    assert_relative_eq!(0.9, score, epsilon = 0.0001);
+
+    // Check the picker picked the correct action
+    let picked = world.get::<Picker>(actor).unwrap().picked;
+    assert_eq!(
+        drink_action, picked,
+        "Picker should have picked drink_action (score=0.9 > threshold=0.5)"
+    );
+
+    // Request the picked action
+    world.commands().trigger(RequestAction::picked(actor));
+    world.flush();
+
+    // Verify the action was initiated
+    let current_action = world.get::<CurrentAction>(actor).unwrap().0;
+    assert_eq!(
+        drink_action, current_action,
+        "Actor should have switched to drinking action"
+    );
+    assert!(world.get::<DrinkAction>(actor).is_some(), "DrinkAction should be active");
+}
+
+/// Test multiple actors with different scores and actions
+#[test]
+fn test_multiple_actors() {
+    let mut app = App::new();
+    app.add_plugins(ObservedUtilityPlugins::TurnBased);
+
+    app.add_observer(on_action_initiated_insert_default::<Action1>);
+    app.add_observer(on_action_initiated_insert_default::<Action2>);
+
+    let world = app.world_mut();
+
+    let action1 = world.register_component::<Action1>();
+    let action2 = world.register_component::<Action2>();
+    let idle_action = world.register_component::<IdleAction>();
+
+    let mut commands = world.commands();
+
+    // Actor 1: High score, should pick action1
+    let scorer1 = commands.spawn((Score::new(0.8), MyMarker)).id();
+    let actor1 = commands
+        .spawn((
+            Picker::new(idle_action).with(scorer1, action1),
+            FirstToScore::new(0.5),
+            CurrentAction(idle_action),
+        ))
+        .add_child(scorer1)
+        .id();
+
+    // Actor 2: Low score, should stay idle
+    let scorer2 = commands.spawn((Score::new(0.2), MyMarker)).id();
+    let actor2 = commands
+        .spawn((
+            Picker::new(idle_action).with(scorer2, action2),
+            FirstToScore::new(0.5),
+            CurrentAction(idle_action),
+        ))
+        .add_child(scorer2)
+        .id();
+
+    world.flush();
+
+    // Run scoring and picking for all
+    world.commands().trigger(RunScoring::all());
+    world.commands().trigger(RunPicking::all());
+    world.flush();
+
+    // Request actions for both actors
+    world.commands().trigger(RequestAction::picked(actor1));
+    world.commands().trigger(RequestAction::picked(actor2));
+    world.flush();
+
+    // Verify actor1 picked action1
+    assert_eq!(action1, world.get::<CurrentAction>(actor1).unwrap().0);
+    assert!(world.get::<Action1>(actor1).is_some());
+
+    // Verify actor2 stayed idle (score too low)
+    assert_eq!(idle_action, world.get::<CurrentAction>(actor2).unwrap().0);
+    assert!(world.get::<Action2>(actor2).is_none());
+}
+
+// Helper components for tests
+#[derive(Component)]
+struct MyAction;
+
+#[derive(Component)]
+struct IdleAction;
+
+#[derive(Component, Default)]
+struct TestAction;
+
+#[derive(Component, Default)]
+struct Action1;
+
+#[derive(Component, Default)]
+struct Action2;
+
+#[derive(Component, Default)]
+struct DrinkAction;
+
+#[derive(Component)]
+struct MyMarker;
+
+#[derive(Component)]
+struct ThirstMarker;


### PR DESCRIPTION
Migration to 16.1 with Claude help went smoothly. A suggested update to Readme.md and versioning is included. Other dependencies were updated as well while we are at it.

 - Update Bevy dependency to version 16.1 in Cargo.toml
  - Add hashbrown 0.15 dependency for Entry type compatibility

  Breaking API changes fixed:
  - Replace trigger.entity() with trigger.target() across all observers
  - Update Parent to ChildOf with parent.get() → parent.parent()
  - Implement new TriggerTargets trait methods returning iterators instead of slices
  - Add required Mutability associated type to all Component implementations
  - Update component hook signatures (remove third parameter from closures)
  - Fix QueryEntityError enum usage with proper archetype parameter
  - Update Once command structure to use FnOnce with proper Send bounds
  - Remove Component reflection from Event types in event.rs
  - Fix ReferenceType trait bounds for mutable references

  Examples and tests:
  - Update thirst example to remove LogPlugin dependency
  - Add println! statements for console output visibility
  - Fix test imports (remove hierarchy module references)
  - All tests passing (12 unit tests + 11 doc tests)